### PR TITLE
chore(release): bump versions for 7.16 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,12 @@
 
   <properties>
     <!-- set the version for camunda BPM here -->
-    <version.camunda>7.15.0</version.camunda>
+    <version.camunda>7.16.0</version.camunda>
     <version.junit>4.13.1</version.junit>
-    <version.assertj>3.18.1</version.assertj>
-    <version.slf4j>1.7.26</version.slf4j>
+    <version.assertj>3.20.2</version.assertj>
+    <version.slf4j>1.7.32</version.slf4j>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
* bumps Camunda to 7.16.0
* bumps AssertJ to 3.20.2
* bumps SLF4J to 1.7.32
* adds maven compiler source and target versions

related to CAM-13917